### PR TITLE
Add centralized API rate limit tracking and pre-call enforcement

### DIFF
--- a/data_collector.py
+++ b/data_collector.py
@@ -12,6 +12,7 @@ from dotenv import load_dotenv
 from datetime import datetime, timedelta
 from pathlib import Path
 from src.api.client import CachedVehicleClient
+from src.api.rate_limiter import get_rate_limiter
 from src.storage.csv_store import CSVStorage
 
 sys.path.append(str(Path(__file__).parent))
@@ -64,121 +65,79 @@ class DataCollector:
             logger.error("Invalid daily limit: %d", self.daily_limit)
             raise ValueError("Daily limit must be a positive integer")
         self.collection_interval_minutes = (24 * 60) // self.daily_limit  # Minutes between collections
-        self.calls_today = 0
-        self.last_reset = datetime.now().date()
-        self.last_call_time = None
-        
-        # Load call history
-        self.call_history_file = Path("data/api_call_history.json")
-        self.load_call_history()
-    
-    def load_call_history(self):
-        """Load API call history from file"""
-        if self.call_history_file.exists():
-            try:
-                with open(self.call_history_file, 'r', encoding='utf-8') as f:
-                    history = json.load(f)
-                    last_reset_str = history.get('last_reset', str(datetime.now().date()))
-                    self.last_reset = datetime.fromisoformat(last_reset_str).date()
-                    self.calls_today = history.get('calls_today', 0)
-                    
-                    # Load last call time
-                    last_call_str = history.get('last_call')
-                    if last_call_str:
-                        self.last_call_time = datetime.fromisoformat(last_call_str)
-                    
-                    # Reset if it's a new day
-                    if self.last_reset < datetime.now().date():
-                        self.reset_daily_counter()
-            except (IOError, json.JSONDecodeError) as e:
-                logger.error("Error loading call history: %s", e)
-                self.reset_daily_counter()
-    
-    def save_call_history(self):
-        """Save API call history to file"""
-        try:
-            self.call_history_file.parent.mkdir(exist_ok=True)
-            with open(self.call_history_file, 'w', encoding='utf-8') as f:
-                json.dump({
-                    'last_reset': str(self.last_reset),
-                    'calls_today': self.calls_today,
-                    'last_call': datetime.now().isoformat()
-                }, f, indent=2)
-        except (IOError, json.JSONDecodeError) as e:
-            logger.error("Error saving call history: %s", e)
-    
-    def reset_daily_counter(self):
-        """Reset the daily API call counter"""
-        self.calls_today = 0
-        self.last_reset = datetime.now().date()
-        self.last_call_time = None
-        self._rate_limit_backoff = 1.0  # Reset backoff on daily reset
-        self.save_call_history()
-        logger.info("Daily API call counter reset")
-    
-    def _extend_next_collection_interval(self):
-        """Extend the next collection interval due to rate limiting"""
-        if hasattr(self, '_rate_limit_backoff'):
-            self._rate_limit_backoff = min(self._rate_limit_backoff * 1.5, 4.0)  # Cap at 4x
-        else:
-            self._rate_limit_backoff = 1.5  # Start with 50% longer interval
-        
-        logger.info(f"Extended collection interval by {self._rate_limit_backoff:.1f}x due to rate limits")
+
+        # Use the shared rate limiter for call tracking
+        self.rate_limiter = get_rate_limiter(daily_limit=self.daily_limit)
+
+        # Legacy attributes kept for backward compat with run_forever logging
+        self.calls_today = self.rate_limiter.calls_today
+        self.last_call_time = self.rate_limiter.last_call_time
     
     def can_make_api_call(self):
         """Check if we can make an API call without exceeding limits"""
-        # Check if it's a new day
-        if self.last_reset < datetime.now().date():
-            self.reset_daily_counter()
-        
-        return self.calls_today < self.daily_limit
+        return self.rate_limiter.can_make_call()
+
+    def _sync_from_tracker(self):
+        """Sync local attributes from the shared rate limiter."""
+        self.calls_today = self.rate_limiter.calls_today
+        self.last_call_time = self.rate_limiter.last_call_time
     
     def collect_data(self):
         """Collect vehicle data from API"""
         if not self.can_make_api_call():
-            logger.warning("Daily API limit reached (%d/%d)", self.calls_today, self.daily_limit)
+            logger.warning(
+                "Daily API limit reached (%d/%d), %d remaining",
+                self.rate_limiter.calls_today,
+                self.rate_limiter.daily_limit,
+                self.rate_limiter.remaining_calls,
+            )
             return False
-        
+
         try:
             logger.info("Collecting vehicle data...")
-            
-            # Get fresh data and let it cache
-            data = self.client.get_vehicle_data()
-            
+
+            # get_vehicle_data now records the call via the shared rate limiter
+            data = self.client.get_vehicle_data(source="data_collector")
+
             if data:
                 # Store in CSV files
                 self.storage.store_vehicle_data(data)
-                
-                # Increment call counter and update last call time
-                self.calls_today += 1
-                self.last_call_time = datetime.now()
-                self.save_call_history()
-                
-                logger.info("Data collected successfully (call %d/%d)", self.calls_today, self.daily_limit)
+
+                # Sync local counters from tracker
+                self._sync_from_tracker()
+
+                logger.info(
+                    "Data collected successfully (call %d/%d, %d remaining)",
+                    self.rate_limiter.calls_today,
+                    self.rate_limiter.daily_limit,
+                    self.rate_limiter.remaining_calls,
+                )
                 # Temperature from API is in Fahrenheit
                 temp_f = data.get('raw_data', {}).get('airTemp', {}).get('value')
                 battery_info = data.get('battery', {})
-                
-                logger.info("Battery: %s%%, Range: %skm, Temp: %s°F", 
-                          battery_info.get('level', 'N/A'), 
-                          battery_info.get('range', 'N/A'), 
+
+                logger.info("Battery: %s%%, Range: %skm, Temp: %s°F",
+                          battery_info.get('level', 'N/A'),
+                          battery_info.get('range', 'N/A'),
                           temp_f if temp_f else 'N/A')
                 return True
             else:
                 logger.error("Failed to collect data - no data returned")
                 return False
-                
+
         except Exception as e:
             error_msg = str(e).lower()
-            
+
             # Check for rate limit errors
             if any(phrase in error_msg for phrase in [
-                'rate limit', 'too many requests', 'quota exceeded', 
+                'rate limit', 'too many requests', 'quota exceeded',
                 'throttled', '429', 'limit exceeded'
             ]):
-                logger.warning("Rate limit exceeded, will extend next collection interval")
-                # Extend the next collection by 50% to avoid further rate limits
-                self._extend_next_collection_interval()
+                self.rate_limiter.record_rate_limit_hit(
+                    source="data_collector",
+                    error_message=str(e),
+                )
+                logger.warning("Rate limit exceeded, backoff now %.1fx", self.rate_limiter.backoff_multiplier)
                 return False
             else:
                 logger.error("Error collecting data: %s", e)
@@ -187,19 +146,22 @@ class DataCollector:
     def calculate_next_collection_time(self):
         """Calculate optimal collection times based on last call and interval"""
         now = datetime.now()
-        
+        self._sync_from_tracker()
+
         # If we have a last call time, calculate next time based on interval
         if self.last_call_time:
-            # Apply rate limit backoff if active
-            backoff_multiplier = getattr(self, '_rate_limit_backoff', 1.0)
-            adjusted_interval = self.collection_interval_minutes * backoff_multiplier
-            
+            # Apply rate limit backoff from the shared tracker
+            adjusted_interval = self.rate_limiter.adjusted_interval_minutes
+
             next_time = self.last_call_time + timedelta(minutes=adjusted_interval)
-            
+
             # If next time is in the future, use it
             if next_time > now:
-                if backoff_multiplier > 1.0:
-                    logger.info(f"Next collection delayed by {backoff_multiplier:.1f}x due to rate limits")
+                if self.rate_limiter.backoff_multiplier > 1.0:
+                    logger.info(
+                        "Next collection delayed by %.1fx due to rate limits (interval: %.0f min)",
+                        self.rate_limiter.backoff_multiplier, adjusted_interval,
+                    )
                 return next_time
         
         # Otherwise, use the scheduled times for today

--- a/src/api/rate_limiter.py
+++ b/src/api/rate_limiter.py
@@ -1,0 +1,284 @@
+"""
+Centralized API rate limit tracking for all components (data collector, web app, API client).
+
+Provides:
+- Shared daily call counter persisted to disk
+- Rate limit event logging with timestamps
+- Backoff state that survives process restarts
+- Pre-call limit checking to prevent exceeding quotas
+- File-level locking for safe multi-process access
+"""
+
+import json
+import logging
+import fcntl
+from datetime import datetime, timedelta
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Singleton instance
+_instance = None
+
+
+def get_rate_limiter(daily_limit=None, data_dir="data"):
+    """Get or create the singleton RateLimitTracker instance."""
+    global _instance
+    if _instance is None:
+        _instance = RateLimitTracker(daily_limit=daily_limit, data_dir=data_dir)
+    return _instance
+
+
+class RateLimitTracker:
+    """Tracks API call usage and rate limit events across all components.
+
+    State is persisted to data/api_call_history.json so it survives restarts
+    and is shared between the data collector process and the Flask web app.
+    """
+
+    def __init__(self, daily_limit=None, data_dir="data"):
+        import os
+        self.daily_limit = daily_limit or int(os.getenv("API_DAILY_LIMIT", "30"))
+        self.data_dir = Path(data_dir)
+        self.data_dir.mkdir(exist_ok=True)
+
+        self.history_file = self.data_dir / "api_call_history.json"
+        self.rate_limit_log_file = self.data_dir / "rate_limit_events.json"
+
+        # In-memory state (loaded from disk)
+        self.calls_today = 0
+        self.last_reset = datetime.now().date()
+        self.last_call_time = None
+        self.backoff_multiplier = 1.0
+        self.call_sources = []  # recent call sources for debugging
+
+        self._load_state()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def can_make_call(self):
+        """Check whether an API call is allowed right now.
+
+        Returns True if we are under the daily limit.
+        Automatically resets the counter at midnight.
+        """
+        self._maybe_reset_day()
+        return self.calls_today < self.daily_limit
+
+    @property
+    def remaining_calls(self):
+        """Number of API calls remaining today."""
+        self._maybe_reset_day()
+        return max(0, self.daily_limit - self.calls_today)
+
+    @property
+    def collection_interval_minutes(self):
+        """Minutes between collections based on daily limit."""
+        return (24 * 60) / self.daily_limit
+
+    @property
+    def adjusted_interval_minutes(self):
+        """Collection interval adjusted by current backoff multiplier."""
+        return self.collection_interval_minutes * self.backoff_multiplier
+
+    def record_call(self, source="unknown"):
+        """Record that an API call was made.
+
+        Args:
+            source: Identifier for what triggered the call
+                    (e.g. 'data_collector', 'web_refresh', 'web_force_update')
+        """
+        self._maybe_reset_day()
+        self.calls_today += 1
+        self.last_call_time = datetime.now()
+
+        # Keep last 50 call sources for debugging
+        self.call_sources.append({
+            "time": self.last_call_time.isoformat(),
+            "source": source,
+            "call_number": self.calls_today,
+        })
+        if len(self.call_sources) > 50:
+            self.call_sources = self.call_sources[-50:]
+
+        self._save_state()
+        logger.info(
+            "API call recorded [source=%s] (%d/%d today)",
+            source, self.calls_today, self.daily_limit,
+        )
+
+    def record_rate_limit_hit(self, source="unknown", error_message=""):
+        """Record that a rate limit error was received from the API.
+
+        Extends the backoff multiplier and logs the event.
+        """
+        self.backoff_multiplier = min(self.backoff_multiplier * 1.5, 4.0)
+        self._save_state()
+
+        event = {
+            "timestamp": datetime.now().isoformat(),
+            "source": source,
+            "error_message": str(error_message)[:500],
+            "calls_at_time": self.calls_today,
+            "daily_limit": self.daily_limit,
+            "backoff_multiplier": self.backoff_multiplier,
+        }
+        self._append_rate_limit_event(event)
+        logger.warning(
+            "Rate limit hit [source=%s] calls=%d/%d backoff=%.1fx: %s",
+            source, self.calls_today, self.daily_limit,
+            self.backoff_multiplier, str(error_message)[:200],
+        )
+
+    def get_status(self):
+        """Return a dict with current rate limit status for API/dashboard use."""
+        self._maybe_reset_day()
+        now = datetime.now()
+
+        # Calculate next collection time
+        next_collection = None
+        if self.last_call_time:
+            next_collection = self.last_call_time + timedelta(
+                minutes=self.adjusted_interval_minutes
+            )
+            if next_collection <= now:
+                next_collection = now + timedelta(seconds=30)
+
+        # Time until daily reset
+        tomorrow = now.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
+        minutes_until_reset = (tomorrow - now).total_seconds() / 60
+
+        return {
+            "calls_today": self.calls_today,
+            "daily_limit": self.daily_limit,
+            "remaining_calls": self.remaining_calls,
+            "last_call": self.last_call_time.isoformat() if self.last_call_time else None,
+            "next_collection": next_collection.isoformat() if next_collection else None,
+            "collection_interval_minutes": round(self.collection_interval_minutes, 1),
+            "backoff_multiplier": self.backoff_multiplier,
+            "adjusted_interval_minutes": round(self.adjusted_interval_minutes, 1),
+            "minutes_until_reset": round(minutes_until_reset, 1),
+            "is_rate_limited": self.backoff_multiplier > 1.0,
+            "recent_calls": self.call_sources[-10:],
+            "recent_rate_limit_events": self._get_recent_rate_limit_events(5),
+        }
+
+    def reset_backoff(self):
+        """Manually reset the backoff multiplier (e.g. after successful call)."""
+        if self.backoff_multiplier > 1.0:
+            logger.info(
+                "Backoff reset from %.1fx to 1.0x after successful call",
+                self.backoff_multiplier,
+            )
+            self.backoff_multiplier = 1.0
+            self._save_state()
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def _load_state(self):
+        """Load persisted state from disk with file locking."""
+        if not self.history_file.exists():
+            return
+
+        try:
+            with open(self.history_file, "r", encoding="utf-8") as f:
+                fcntl.flock(f, fcntl.LOCK_SH)
+                try:
+                    data = json.load(f)
+                finally:
+                    fcntl.flock(f, fcntl.LOCK_UN)
+
+            last_reset_str = data.get("last_reset", str(datetime.now().date()))
+            self.last_reset = datetime.fromisoformat(last_reset_str).date()
+            self.calls_today = data.get("calls_today", 0)
+            self.backoff_multiplier = data.get("backoff_multiplier", 1.0)
+            self.call_sources = data.get("call_sources", [])
+
+            last_call_str = data.get("last_call")
+            if last_call_str:
+                self.last_call_time = datetime.fromisoformat(last_call_str)
+
+            # Reset if it's a new day
+            self._maybe_reset_day()
+
+        except (IOError, json.JSONDecodeError, ValueError) as exc:
+            logger.error("Error loading rate limit state: %s", exc)
+            self._maybe_reset_day()
+
+    def _save_state(self):
+        """Persist current state to disk with file locking."""
+        try:
+            self.data_dir.mkdir(exist_ok=True)
+            with open(self.history_file, "w", encoding="utf-8") as f:
+                fcntl.flock(f, fcntl.LOCK_EX)
+                try:
+                    json.dump(
+                        {
+                            "last_reset": str(self.last_reset),
+                            "calls_today": self.calls_today,
+                            "last_call": self.last_call_time.isoformat()
+                                if self.last_call_time else None,
+                            "backoff_multiplier": self.backoff_multiplier,
+                            "call_sources": self.call_sources,
+                        },
+                        f,
+                        indent=2,
+                    )
+                finally:
+                    fcntl.flock(f, fcntl.LOCK_UN)
+        except IOError as exc:
+            logger.error("Error saving rate limit state: %s", exc)
+
+    def _maybe_reset_day(self):
+        """Reset counters if the date has rolled over."""
+        today = datetime.now().date()
+        if self.last_reset < today:
+            logger.info(
+                "New day detected — resetting API call counter "
+                "(previous: %d calls on %s)",
+                self.calls_today, self.last_reset,
+            )
+            self.calls_today = 0
+            self.last_reset = today
+            self.last_call_time = None
+            self.backoff_multiplier = 1.0
+            self.call_sources = []
+            self._save_state()
+
+    # ------------------------------------------------------------------
+    # Rate limit event log
+    # ------------------------------------------------------------------
+
+    def _append_rate_limit_event(self, event):
+        """Append a rate limit event to the log file."""
+        events = self._load_rate_limit_events()
+        events.append(event)
+
+        # Keep last 200 events
+        if len(events) > 200:
+            events = events[-200:]
+
+        try:
+            with open(self.rate_limit_log_file, "w", encoding="utf-8") as f:
+                json.dump(events, f, indent=2)
+        except IOError as exc:
+            logger.error("Error writing rate limit event log: %s", exc)
+
+    def _load_rate_limit_events(self):
+        """Load rate limit event log from disk."""
+        if not self.rate_limit_log_file.exists():
+            return []
+        try:
+            with open(self.rate_limit_log_file, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except (IOError, json.JSONDecodeError):
+            return []
+
+    def _get_recent_rate_limit_events(self, count=5):
+        """Get the N most recent rate limit events."""
+        events = self._load_rate_limit_events()
+        return events[-count:] if events else []

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -12,6 +12,7 @@ import pandas as pd
 sys.path.append(str(Path(__file__).parent.parent.parent))
 
 from src.api.client import CachedVehicleClient, APIError
+from src.api.rate_limiter import get_rate_limiter
 from src.storage.csv_store import CSVStorage
 from src.web.cache_routes import cache_bp
 from src.web.debug_routes import debug_bp
@@ -87,11 +88,11 @@ def clear_cache():
 def refresh_data():
     if not client:
         return jsonify({"status": "error", "message": "API client not initialized. Please check your .env configuration."}), 500
-    
+
     try:
         # Force a cache update to get fresh data
-        # Note: timeout is handled within the client
-        data = client.force_cache_update()
+        # The client checks rate limits internally and raises APIError if exceeded
+        data = client.force_cache_update(source="web_refresh")
         
         if data:
             storage.store_vehicle_data(data)
@@ -852,64 +853,32 @@ def get_charging_sessions():
 
 @app.route('/api/collection-status')
 def get_collection_status():
-    """Get data collection status"""
+    """Get data collection status including rate limit information"""
     try:
-        history_file = Path('data/api_call_history.json')
-        if history_file.exists():
-            with open(history_file, 'r') as f:
-                history = json.load(f)
-                
-            # Calculate next collection time
-            calls_today = history.get('calls_today', 0)
-            daily_limit = int(os.getenv('API_DAILY_LIMIT', 30))
-            
-            if calls_today < daily_limit:
-                # Calculate based on evenly distributed collections
-                last_call_str = history.get('last_call')
-                interval_minutes = (24 * 60) // daily_limit
-                now = datetime.now()
-                
-                if last_call_str:
-                    last_call = datetime.fromisoformat(last_call_str)
-                    next_collection = last_call + timedelta(minutes=interval_minutes)
-                    
-                    # If the calculated time has passed, find the next scheduled slot
-                    if next_collection <= now:
-                        # Calculate today's scheduled times
-                        today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
-                        
-                        # Find next available slot
-                        for i in range(calls_today, daily_limit):
-                            scheduled_time = today_start + timedelta(minutes=interval_minutes * i)
-                            if scheduled_time > now:
-                                next_collection = scheduled_time
-                                break
-                        else:
-                            # No more slots today, schedule for tomorrow
-                            tomorrow = today_start + timedelta(days=1)
-                            next_collection = tomorrow
-                else:
-                    # No last call, schedule for next available slot
-                    next_collection = now + timedelta(minutes=1)
-            else:
-                # Next collection tomorrow at midnight
-                tomorrow = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=1)
-                next_collection = tomorrow
-            
-            return jsonify({
-                'calls_today': calls_today,
-                'daily_limit': daily_limit,
-                'next_collection': next_collection.isoformat(),
-                'last_call': history.get('last_call')
-            })
-        else:
-            daily_limit = int(os.getenv('API_DAILY_LIMIT', 30))
-            return jsonify({
-                'calls_today': 0,
-                'daily_limit': daily_limit,
-                'next_collection': None,
-                'last_call': None
-            })
+        rate_limiter = get_rate_limiter()
+        status = rate_limiter.get_status()
+
+        return jsonify({
+            'calls_today': status['calls_today'],
+            'daily_limit': status['daily_limit'],
+            'remaining_calls': status['remaining_calls'],
+            'next_collection': status['next_collection'],
+            'last_call': status['last_call'],
+            'collection_interval_minutes': status['collection_interval_minutes'],
+            'is_rate_limited': status['is_rate_limited'],
+            'backoff_multiplier': status['backoff_multiplier'],
+            'adjusted_interval_minutes': status['adjusted_interval_minutes'],
+            'minutes_until_reset': status['minutes_until_reset'],
+        })
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/rate-limit-status')
+def get_rate_limit_status():
+    """Get detailed rate limit status for debugging and dashboard display"""
+    try:
+        rate_limiter = get_rate_limiter()
+        return jsonify(rate_limiter.get_status())
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -110,9 +110,12 @@ def refresh_data():
             else:
                 freshness_msg = ""
             
+            data_source = data.get('data_source', 'unknown')
             return jsonify({
-                "status": "success", 
-                "message": f"Data refreshed successfully{freshness_msg}"
+                "status": "success",
+                "message": f"Data refreshed successfully{freshness_msg}",
+                "data_source": data_source,
+                "hyundai_data_fresh": data.get('hyundai_data_fresh'),
             })
         else:
             return jsonify({
@@ -938,6 +941,7 @@ def get_current_status():
                 response_data['api_last_updated'] = latest_cache_data['api_last_updated']
             if latest_cache_data:
                 response_data['hyundai_data_fresh'] = latest_cache_data.get('hyundai_data_fresh')
+                response_data['data_source'] = latest_cache_data.get('data_source')
 
             # Add weather data if available
             if weather_data:

--- a/src/web/cache_routes.py
+++ b/src/web/cache_routes.py
@@ -156,9 +156,12 @@ def force_cache_update():
         # The client checks rate limits internally and raises APIError if exceeded
         data = client.force_cache_update(source="web_force_update")
         if data:
+            data_source = data.get('data_source', 'unknown')
             return jsonify({
                 'success': True,
                 'message': 'Cache updated successfully',
+                'data_source': data_source,
+                'hyundai_data_fresh': data.get('hyundai_data_fresh'),
                 'data': {
                     'battery_level': data.get('battery', {}).get('level'),
                     'range': data.get('battery', {}).get('range'),

--- a/src/web/static/css/style.css
+++ b/src/web/static/css/style.css
@@ -1187,3 +1187,14 @@ canvas {
     background-color: rgba(243, 156, 18, 0.1);
     border: 1px solid rgba(243, 156, 18, 0.3);
 }
+
+/* Rate limit warning in collection status section */
+.rate-limit-info {
+    color: var(--warning-color);
+    background-color: rgba(243, 156, 18, 0.1);
+    border: 1px solid rgba(243, 156, 18, 0.3);
+    border-radius: 4px;
+    padding: 0.5rem 0.75rem;
+    margin-top: 0.5rem;
+    font-size: 0.9em;
+}

--- a/src/web/templates/cache.html
+++ b/src/web/templates/cache.html
@@ -356,8 +356,16 @@
                 const data = await response.json();
                 
                 if (response.ok) {
-                    showSuccess(`Cache updated! Battery: ${data.data.battery_level}%, Range: ${data.data.range}km, Temp: ${data.data.temperature}°F`);
+                    let sourceInfo = '';
+                    if (data.data_source === 'api_fresh') {
+                        sourceInfo = ' (fresh vehicle data)';
+                    } else if (data.data_source === 'api_stale') {
+                        sourceInfo = ' (Hyundai returned cached vehicle data)';
+                    }
+                    showSuccess(`Cache updated${sourceInfo}! Battery: ${data.data.battery_level}%, Range: ${data.data.range}km, Temp: ${data.data.temperature}°F`);
                     loadFiles();
+                } else if (response.status === 429) {
+                    showError(data.error || 'Daily API rate limit reached. Try again tomorrow.');
                 } else {
                     showError(data.error || 'Failed to update cache');
                 }

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -210,6 +210,7 @@
             <div class="collection-info">
                 <p>API Calls Today: <span id="api-calls-today">--</span></p>
                 <p>Next Collection: <span id="next-collection">--</span></p>
+                <p id="rate-limit-info" class="rate-limit-info" style="display: none;" role="alert"></p>
             </div>
         </section>
     </main>


### PR DESCRIPTION
The Hyundai API rate limiting was handled reactively (detected only after
hitting limits) and inconsistently across components. Web endpoints could
bypass the daily call counter entirely, and backoff state was lost on restart.

This introduces a shared RateLimitTracker (src/api/rate_limiter.py) that:
- Provides a single source of truth for API call counting across data
  collector, web app, and API client
- Enforces daily limits proactively (checks before calling, not after)
- Persists backoff state to disk with file locking for safe multi-process access
- Logs rate limit events to data/rate_limit_events.json for analysis
- Tracks call sources (data_collector, web_refresh, web_force_update)
- Exposes /api/rate-limit-status endpoint for dashboard visibility
- Enriches /api/collection-status with remaining calls, backoff info,
  and minutes until daily reset

https://claude.ai/code/session_01Aa4D9ims9SRnufsE9xd1BH