### PR TITLE
Add REST API endpoint for external 12V battery data ingestion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ API_DAILY_LIMIT=30  # Maximum API calls per day
 TZ=America/Chicago  # Timezone (Minnesota is Central Time)
 DEBUG_MODE=false  # Set to true for verbose logging and debug features
 
+# External API (for Raspberry Pi / BM2 12V battery monitor)
+EXTERNAL_API_KEY=your-external-api-key-here
+
 # Nginx proxy settings (for nginx-proxy-network)
 VIRTUAL_HOST=pyvisionic.example.com  # Your domain name
 VIRTUAL_PORT=5000  # Should match PORT above

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas==2.1.4
 plotly==5.18.0
 gunicorn==21.2.0
 simplejson==3.19.2
+filelock>=3.12

--- a/src/storage/csv_store.py
+++ b/src/storage/csv_store.py
@@ -25,7 +25,6 @@ Usage:
     locations_df = storage.get_locations_df()
 """
 import csv
-import io
 import logging
 import os
 from datetime import datetime
@@ -639,10 +638,13 @@ class CSVStorage:
             if size > read_size:
                 lines = lines[1:]  # first line is likely truncated
 
-            reader = csv.DictReader(lines)
+            reader = csv.reader(lines)
             for row in reader:
-                ts = row.get('timestamp', '').strip()
-                if ts:
+                if not row:
+                    continue
+                ts = row[0].strip()
+                # Skip the header row if it ended up in our tail chunk
+                if ts and ts != 'timestamp':
                     timestamps.add(ts)
         except Exception as e:
             logger.warning("Could not read recent timestamps from %s: %s", filepath, e)

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -15,6 +15,7 @@ from src.api.client import CachedVehicleClient, APIError
 from src.storage.csv_store import CSVStorage
 from src.web.cache_routes import cache_bp
 from src.web.debug_routes import debug_bp
+from src.web.external_routes import external_bp
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = 'dev-secret-key'
@@ -29,10 +30,12 @@ except Exception as e:
     app.config['cache_client'] = None
 
 storage = CSVStorage()
+app.config['storage'] = storage
 
 # Register blueprints
 app.register_blueprint(cache_bp)
 app.register_blueprint(debug_bp)
+app.register_blueprint(external_bp)
 
 def clean_nan_values(data):
     """Replace NaN and None values with None for JSON serialization"""

--- a/src/web/external_routes.py
+++ b/src/web/external_routes.py
@@ -1,0 +1,95 @@
+import logging
+import os
+from pathlib import Path
+
+from flask import Blueprint, jsonify, request
+
+external_bp = Blueprint('external', __name__)
+
+logger = logging.getLogger('external_api')
+
+# Add a file handler so external API activity lands in logs/collector.log
+_log_dir = Path('logs')
+_log_dir.mkdir(exist_ok=True)
+_fh = logging.FileHandler(_log_dir / 'collector.log')
+_fh.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+logger.addHandler(_fh)
+logger.setLevel(logging.INFO)
+
+
+def _check_api_key():
+    """Validate the X-API-KEY header against the configured EXTERNAL_API_KEY."""
+    expected_key = os.getenv('EXTERNAL_API_KEY')
+    if not expected_key:
+        return False, "EXTERNAL_API_KEY not configured on server"
+    provided_key = request.headers.get('X-API-KEY')
+    if not provided_key or provided_key != expected_key:
+        return False, "Invalid or missing API key"
+    return True, None
+
+
+@external_bp.route('/api/external/battery', methods=['POST'])
+def post_external_battery():
+    """Accept 12V battery data from an external device (e.g. Raspberry Pi + BM2).
+
+    Expected JSON payload:
+        {
+            "voltage": float,   # required
+            "soc": float,       # required
+            "temp": float       # optional
+        }
+
+    Headers:
+        X-API-KEY: <EXTERNAL_API_KEY>
+    """
+    # --- Auth ---
+    auth_ok, auth_error = _check_api_key()
+    if not auth_ok:
+        logger.warning("[EXTERNAL_API] Unauthorized request from %s: %s",
+                       request.remote_addr, auth_error)
+        return jsonify({"error": auth_error}), 401
+
+    # --- Parse body ---
+    data = request.get_json(silent=True)
+    if not data:
+        return jsonify({"error": "Request body must be valid JSON"}), 400
+
+    voltage = data.get('voltage')
+    soc = data.get('soc')
+    temp = data.get('temp')
+
+    # --- Validate required fields ---
+    errors = []
+    if voltage is None:
+        errors.append("'voltage' is required")
+    elif not isinstance(voltage, (int, float)):
+        errors.append("'voltage' must be a number")
+
+    if soc is None:
+        errors.append("'soc' is required")
+    elif not isinstance(soc, (int, float)):
+        errors.append("'soc' must be a number")
+
+    if temp is not None and not isinstance(temp, (int, float)):
+        errors.append("'temp' must be a number if provided")
+
+    if errors:
+        return jsonify({"error": "Validation failed", "details": errors}), 400
+
+    # --- Persist via CSVStorage ---
+    from flask import current_app
+    storage = current_app.config.get('storage')
+    if storage is None:
+        logger.error("[EXTERNAL_API] CSVStorage not available in app config")
+        return jsonify({"error": "Storage not available"}), 500
+
+    row = storage.store_external_battery(
+        voltage=float(voltage),
+        soc=float(soc),
+        temperature=float(temp) if temp is not None else None,
+    )
+
+    logger.info("[EXTERNAL_API] Stored 12V battery data: voltage=%.2f soc=%.1f temp=%s",
+                voltage, soc, temp)
+
+    return jsonify({"status": "created", "data": row}), 201


### PR DESCRIPTION
Allows external devices (e.g. Raspberry Pi + BM2 BLE battery monitor) to
POST 12V voltage, SoC, and temperature readings via /api/external/battery.
Data is persisted to data/external_battery.csv through CSVStorage, with
API key authentication via X-API-KEY header (configured by EXTERNAL_API_KEY
env var). Logs activity to logs/collector.log as [EXTERNAL_API].

https://claude.ai/code/session_01NZ37FMuM7xVAGd8towMRmF